### PR TITLE
Exporting Other Workout Types

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,4 +1,4 @@
 # Privacy Policy
 _Workout_ access user Health data only for exporting purposes and created CSV files are only stored inside the app container as temporary files strictly for the time the user chooses how to export them using built-in iOS capabilities, nor they are sent to any other service besides where the user chooses to export them.
 
-_Workout_ access only workouts, heart rate, step count and distance run data after receiving user consent and can function as normal if the user doesn't want to give access to some of these, although denying access to workouts data will render the app useless.
+_Workout_ access only workouts, heart rate, step count, swimming strokes, distance run and swum data after receiving user consent and can function as normal if the user doesn't want to give access to some of these, although denying access to workouts data will render the app useless.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Workout
-Do you go jogging and record your workout with your Apple Watch? Do you want to have access to recorded data to organise it as you please?
+Do you go jogging and record your workout with your Apple Watch or record any workout in any other way? Do you want to have access to recorded data to organise it as you please?
+With Workout you can export all your workouts saved inside the Health app to a CSV file and import them to your favorite spreadsheet app and view any detail:
+- General data such as distance, duration, heart rate, average pace and speed
+- Minute by minute details for supported workouts:
+  - Running: pace, heart rate, step count
+  - Swimming: speed, heart rate, stroke count
 
-With Workout you can export all your jogging workout to a CSV file and import them to your favorite spreadsheet app and view any detail:
-- General data such as distance, duration, average pace and heart rate
-- Minute by minute pace, heart rate and step count
 
 [![Download on the AppStore](http://www.marcoboschi.altervista.org/img/app_store_en.svg)](https://itunes.apple.com/us/app/workout-csv-exporter/id1140433100?ls=1&mt=8)
 
@@ -11,15 +13,14 @@ With Workout you can export all your jogging workout to a CSV file and import th
 This project relies on CocoaPods not included the repository, after cloning run
 
     pod install
-    
+
 in a terminal in the project directory to download linked frameworks and use `Workout.xcworkspace` to open the project.
 
-The framework `MBLibrary` referenced by this project is available [here](https://github.com/piscoTech/MBLibrary), version currently in use is [1.0.2](https://github.com/piscoTech/MBLibrary/releases/tag/v1.0.2(3)).
+The framework `MBLibrary` referenced by this project is available [here](https://github.com/piscoTech/MBLibrary), version currently in use is [1.0.3](https://github.com/piscoTech/MBLibrary/releases/tag/v1.0.3(4)).
 
 ## Customization
 General behaviour of the app can be configured via global variables in `Main.swift`:
 
-* `authRequired`: When the user authorizes (or denies) Health data access the value of this variable is saved in `UserDefaults`, upon launch the app check the stored values and if it's less than the declared value the authorization form will be displayed. New versions of the app that requires access to new data should increase this value to automatically display the authorization form.
+* `authRequired` and `healthReadData`: Used to save the latest authorization requested in `UserDefaults`, when the former is greater than the saved value the user will be promped for authorization upon next launch, refer to the [wiki](https://github.com/piscoTech/Workout/wiki) for additional details.
 * `adsEnable`: Display ads override, set this variable to `false` to always hide ads. If this is set to `true` ads will be displayed and hidden accordingly to In-App purchase.
 * `adsID`: AdMob ads key.
-* `stepSourceFilter`: Since both iPhone and Apple Watch track steps during workout only those step data point whose source cointains this value will be considered.

--- a/Workout.xcodeproj/project.pbxproj
+++ b/Workout.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		7A9E3A951D4009AB00CF73ED /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E3A941D4009AB00CF73ED /* Workout.swift */; };
 		7A9E3A971D400A0000CF73ED /* WorkoutMinute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */; };
 		7A9E3A991D400EB900CF73ED /* DataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E3A981D400EB900CF73ED /* DataPoint.swift */; };
+		7AA638441E6C4E0E00F006EB /* WorkoutDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA638431E6C4E0E00F006EB /* WorkoutDetail.swift */; };
 		7AA9F47D1C48EFFF005FFCB3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA9F47C1C48EFFF005FFCB3 /* AppDelegate.swift */; };
 		7AA9F4821C48EFFF005FFCB3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7AA9F4801C48EFFF005FFCB3 /* Main.storyboard */; };
 		7AA9F4841C48EFFF005FFCB3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7AA9F4831C48EFFF005FFCB3 /* Assets.xcassets */; };
@@ -98,6 +99,7 @@
 		7A9E3A941D4009AB00CF73ED /* Workout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
 		7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkoutMinute.swift; sourceTree = "<group>"; };
 		7A9E3A981D400EB900CF73ED /* DataPoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataPoint.swift; sourceTree = "<group>"; };
+		7AA638431E6C4E0E00F006EB /* WorkoutDetail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkoutDetail.swift; sourceTree = "<group>"; };
 		7AA9F4791C48EFFE005FFCB3 /* Workout.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Workout.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AA9F47C1C48EFFF005FFCB3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AA9F4811C48EFFF005FFCB3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				7A812E0B1E6AC1140086ECA7 /* HealthKit.swift */,
 				7A9E3A981D400EB900CF73ED /* DataPoint.swift */,
 				7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */,
+				7AA638431E6C4E0E00F006EB /* WorkoutDetail.swift */,
 				7A2BDCB01E6AF13700996E36 /* Workouts */,
 			);
 			name = Model;
@@ -417,6 +420,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7AA638441E6C4E0E00F006EB /* WorkoutDetail.swift in Sources */,
 				7AA9F4971C48F64E005FFCB3 /* Main.swift in Sources */,
 				7AA9F4951C48F5A1005FFCB3 /* ListTVC.swift in Sources */,
 				7AA9F4991C4904F9005FFCB3 /* WorkoutTVC.swift in Sources */,

--- a/Workout.xcodeproj/project.pbxproj
+++ b/Workout.xcodeproj/project.pbxproj
@@ -8,12 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		00755F3ACCDE2F7F8B9685C3 /* Pods_Workout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC76321FF7F86708B7687C1B /* Pods_Workout.framework */; };
+		7A2BDCB51E6AF21200996E36 /* SwimmingWorkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2BDCB41E6AF21200996E36 /* SwimmingWorkout.swift */; };
+		7A2BDCB71E6AF22600996E36 /* RunningWorkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2BDCB61E6AF22600996E36 /* RunningWorkout.swift */; };
 		7A6D1F4B1D51E4C8002A4890 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6D1F4A1D51E4C8002A4890 /* Preferences.swift */; };
 		7A6D1F501D51EB40002A4890 /* AboutVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6D1F4F1D51EB40002A4890 /* AboutVC.swift */; };
 		7A75FB521D3E52A000F66CF9 /* MBLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A584FCF1D3E2A5A000C739B /* MBLibrary.framework */; };
 		7A75FB531D3E52A000F66CF9 /* MBLibrary.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7A584FCF1D3E2A5A000C739B /* MBLibrary.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7A7858B61D5680EB0068B627 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A7858B51D5680EB0068B627 /* StoreKit.framework */; };
 		7A7D1A281D5E02060048ED64 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7A7D1A2A1D5E02060048ED64 /* Localizable.strings */; };
+		7A812E0C1E6AC1140086ECA7 /* HealthKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A812E0B1E6AC1140086ECA7 /* HealthKit.swift */; };
 		7A8413E61CA1526500B86C48 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A8413E51CA1526500B86C48 /* HealthKit.framework */; };
 		7A9E3A951D4009AB00CF73ED /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E3A941D4009AB00CF73ED /* Workout.swift */; };
 		7A9E3A971D400A0000CF73ED /* WorkoutMinute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */; };
@@ -83,11 +86,14 @@
 /* Begin PBXFileReference section */
 		33FCBA283095BB59F421FA9F /* Pods-Workout.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Workout.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Workout/Pods-Workout.debug.xcconfig"; sourceTree = "<group>"; };
 		42588D93C213509410E5F0B6 /* Pods-Workout.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Workout.release.xcconfig"; path = "Pods/Target Support Files/Pods-Workout/Pods-Workout.release.xcconfig"; sourceTree = "<group>"; };
+		7A2BDCB41E6AF21200996E36 /* SwimmingWorkout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwimmingWorkout.swift; sourceTree = "<group>"; };
+		7A2BDCB61E6AF22600996E36 /* RunningWorkout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RunningWorkout.swift; sourceTree = "<group>"; };
 		7A584FC91D3E2A5A000C739B /* MBLibrary.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MBLibrary.xcodeproj; path = ../MBLibrary/MBLibrary.xcodeproj; sourceTree = "<group>"; };
 		7A6D1F4A1D51E4C8002A4890 /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
 		7A6D1F4F1D51EB40002A4890 /* AboutVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutVC.swift; sourceTree = "<group>"; };
 		7A7858B51D5680EB0068B627 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		7A7D1A291D5E02060048ED64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		7A812E0B1E6AC1140086ECA7 /* HealthKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKit.swift; sourceTree = "<group>"; };
 		7A8413E51CA1526500B86C48 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		7A9E3A941D4009AB00CF73ED /* Workout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
 		7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkoutMinute.swift; sourceTree = "<group>"; };
@@ -130,6 +136,16 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		7A2BDCB01E6AF13700996E36 /* Workouts */ = {
+			isa = PBXGroup;
+			children = (
+				7A9E3A941D4009AB00CF73ED /* Workout.swift */,
+				7A2BDCB61E6AF22600996E36 /* RunningWorkout.swift */,
+				7A2BDCB41E6AF21200996E36 /* SwimmingWorkout.swift */,
+			);
+			name = Workouts;
+			sourceTree = "<group>";
+		};
 		7A584FCA1D3E2A5A000C739B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -162,9 +178,10 @@
 		7A9E3A931D40099D00CF73ED /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				7A812E0B1E6AC1140086ECA7 /* HealthKit.swift */,
 				7A9E3A981D400EB900CF73ED /* DataPoint.swift */,
 				7A9E3A961D400A0000CF73ED /* WorkoutMinute.swift */,
-				7A9E3A941D4009AB00CF73ED /* Workout.swift */,
+				7A2BDCB01E6AF13700996E36 /* Workouts */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -406,7 +423,10 @@
 				7AA9F47D1C48EFFF005FFCB3 /* AppDelegate.swift in Sources */,
 				7AA9F49C1C492BB4005FFCB3 /* WorkoutDetailTVCell.swift in Sources */,
 				7A9E3A971D400A0000CF73ED /* WorkoutMinute.swift in Sources */,
+				7A2BDCB51E6AF21200996E36 /* SwimmingWorkout.swift in Sources */,
+				7A812E0C1E6AC1140086ECA7 /* HealthKit.swift in Sources */,
 				7A6D1F501D51EB40002A4890 /* AboutVC.swift in Sources */,
+				7A2BDCB71E6AF22600996E36 /* RunningWorkout.swift in Sources */,
 				7A9E3A991D400EB900CF73ED /* DataPoint.swift in Sources */,
 				7A9E3A951D4009AB00CF73ED /* Workout.swift in Sources */,
 				7A6D1F4B1D51E4C8002A4890 /* Preferences.swift in Sources */,

--- a/Workout/Base.lproj/Localizable.strings
+++ b/Workout/Base.lproj/Localizable.strings
@@ -24,3 +24,8 @@
 "CANNOT_EXPORT" = "Cannot export workout data";
 "SEL_EXPORT_ALL" = "Select All";
 "SEL_EXPORT_NONE" = "Select None";
+
+"WORKOUT_NAME_0" = "Unknown workout";
+"WORKOUT_NAME_1" = "Running";
+"WORKOUT_NAME_2" = "Strength Training";
+"WORKOUT_NAME_3" = "Swimming";

--- a/Workout/Base.lproj/Localizable.strings
+++ b/Workout/Base.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "LOADING" = "Loading...";
 "ERR_NO_HEALTH" = "Health data is not available";
 
+"TYPE" = "Type";
 "START" = "Start";
 "END" = "End";
 "DURATION" = "Duration";
@@ -20,6 +21,10 @@
 "AVG_HEART" = "Average Heart Rate";
 "MAX_HEART" = "Max Heart Rate";
 "AVG_PACE" = "Average Pace";
+"AVG_SPEED" = "Average Speed";
+
+"STEPS" = "steps";
+"STROKES" = "strokes";
 
 "CANNOT_EXPORT" = "Cannot export workout data";
 "SEL_EXPORT_ALL" = "Select All";

--- a/Workout/Base.lproj/Localizable.strings
+++ b/Workout/Base.lproj/Localizable.strings
@@ -29,8 +29,3 @@
 "CANNOT_EXPORT" = "Cannot export workout data";
 "SEL_EXPORT_ALL" = "Select All";
 "SEL_EXPORT_NONE" = "Select None";
-
-"WORKOUT_NAME_0" = "Unknown workout";
-"WORKOUT_NAME_1" = "Running";
-"WORKOUT_NAME_2" = "Strength Training";
-"WORKOUT_NAME_3" = "Swimming";

--- a/Workout/Base.lproj/Main.storyboard
+++ b/Workout/Base.lproj/Main.storyboard
@@ -158,32 +158,6 @@
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tcy-Pw-goL">
                                             <rect key="frame" x="16" y="0.0" width="351" height="43.5"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[Time]" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="84K-br-dgJ">
-                                                    <rect key="frame" x="0.0" y="11.5" width="50" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[Pace]" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ich-aN-6zQ">
-                                                    <rect key="frame" x="99.5" y="11.5" width="49.5" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[BPM]" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZzE-TL-U1D">
-                                                    <rect key="frame" x="198" y="11.5" width="47.5" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[Steps]" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wub-3Y-wW7">
-                                                    <rect key="frame" x="295" y="11.5" width="56" height="20.5"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
                                         </stackView>
                                     </subviews>
                                     <constraints>
@@ -194,10 +168,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <outlet property="bpm" destination="ZzE-TL-U1D" id="rk0-Dg-MhE"/>
-                                    <outlet property="pace" destination="Ich-aN-6zQ" id="q7r-lT-72M"/>
-                                    <outlet property="steps" destination="Wub-3Y-wW7" id="N8s-zl-WMH"/>
-                                    <outlet property="time" destination="84K-br-dgJ" id="LRo-Yv-q0D"/>
+                                    <outlet property="stack" destination="Tcy-Pw-goL" id="02A-97-oIm"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Workout/Base.lproj/Main.storyboard
+++ b/Workout/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cG8-Sd-LXa">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cG8-Sd-LXa">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>

--- a/Workout/DataPoint.swift
+++ b/Workout/DataPoint.swift
@@ -8,14 +8,20 @@
 
 import Foundation
 
-struct DataPoint {
+protocol DataPoint {
+
+	var value: Double { get }
+
+}
+
+struct InstantDataPoint: DataPoint {
 	
 	let time: TimeInterval
 	let value: Double
 	
 }
 
-struct RangedDataPoint {
+struct RangedDataPoint: DataPoint {
 	
 	let start, end: TimeInterval
 	let value: Double
@@ -30,4 +36,12 @@ struct RangedDataPoint {
 		return end - start
 	}
 	
+}
+
+enum DataPointType {
+	case instant, ranged
+}
+
+enum DataType {
+	case cumulative, average
 }

--- a/Workout/HealthKit.swift
+++ b/Workout/HealthKit.swift
@@ -31,8 +31,4 @@ extension HKUnit {
 		return HKUnit.count()
 	}
 	
-	class func kilometer() -> HKUnit {
-		return HKUnit.meterUnit(with: .kilo)
-	}
-	
 }

--- a/Workout/HealthKit.swift
+++ b/Workout/HealthKit.swift
@@ -1,0 +1,59 @@
+//
+//  HealthKit.swift
+//  Workout
+//
+//  Created by Marco Boschi on 04/03/2017.
+//  Copyright © 2017 Marco Boschi. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+
+extension HKWorkoutActivityType {
+	
+	var name: String {
+		let wType: Int
+		
+		switch self {
+		case .running:
+			wType = 1
+		case .functionalStrengthTraining:
+			wType = 2
+		case .swimming:
+			wType = 3
+		default:
+			wType = 0
+		}
+		
+		return NSLocalizedString("WORKOUT_NAME_\(wType)", comment: "Workout")
+	}
+	
+}
+
+extension HKQuantityTypeIdentifier {
+	
+	func getType() -> HKQuantityType? {
+		return HKObjectType.quantityType(forIdentifier: self)
+	}
+	
+}
+
+extension HKUnit {
+	
+	class func heartRate() -> HKUnit {
+		return HKUnit.count().unitDivided(by: HKUnit.minute())
+	}
+	
+	class func steps() -> HKUnit {
+		return HKUnit.count()
+	}
+	
+	class func strokes() -> HKUnit {
+		return HKUnit.count()
+	}
+	
+	class func kilometer() -> HKUnit {
+		return HKUnit.meterUnit(with: .kilo)
+	}
+	
+}

--- a/Workout/HealthKit.swift
+++ b/Workout/HealthKit.swift
@@ -9,27 +9,6 @@
 import Foundation
 import HealthKit
 
-extension HKWorkoutActivityType {
-	
-	var name: String {
-		let wType: Int
-		
-		switch self {
-		case .running:
-			wType = 1
-		case .functionalStrengthTraining:
-			wType = 2
-		case .swimming:
-			wType = 3
-		default:
-			wType = 0
-		}
-		
-		return NSLocalizedString("WORKOUT_NAME_\(wType)", comment: "Workout")
-	}
-	
-}
-
 extension HKQuantityTypeIdentifier {
 	
 	func getType() -> HKQuantityType? {

--- a/Workout/ListTVC.swift
+++ b/Workout/ListTVC.swift
@@ -72,8 +72,7 @@ class ListTableViewController: UITableViewController, GADBannerViewDelegate, Wor
 	
 			let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: false)
 			let type = HKObjectType.workoutType()
-			let predicate = NSCompoundPredicate(orPredicateWithSubpredicates: workoutTypes.map { HKQuery.predicateForWorkouts(with: $0) })
-			let workoutQuery = HKSampleQuery(sampleType: type, predicate: predicate, limit: Int(HKObjectQueryNoLimit), sortDescriptors: [sortDescriptor]) { (_, r, err) in
+			let workoutQuery = HKSampleQuery(sampleType: type, predicate: nil, limit: HKObjectQueryNoLimit, sortDescriptors: [sortDescriptor]) { (_, r, err) in
 				self.workouts = nil
 				self.err = err
 				if let res = r as? [HKWorkout] {

--- a/Workout/ListTVC.swift
+++ b/Workout/ListTVC.swift
@@ -196,7 +196,10 @@ class ListTableViewController: UITableViewController, GADBannerViewDelegate, Wor
 			self.waitingForExport = self.exportSelection.map { $0 ? 1 : 0 }.reduce(0) { $0 + $1 }
 			for (w, e) in zip(self.workouts, self.exportSelection) {
 				if e {
-					self.exportWorkouts.append(Workout(w, delegate: self))
+					//Use base workout class to avoid loading additional (and unused) detail
+					let workout = Workout(w, delegate: self)
+					workout.load()
+					self.exportWorkouts.append(workout)
 				}
 			}
 		}
@@ -247,7 +250,7 @@ class ListTableViewController: UITableViewController, GADBannerViewDelegate, Wor
 	
 	func dataIsReady() {
 		waitingForExport -= 1;
-		
+		// TODO: Migrate to DispatchQueue.workout when merging in branch:v1.3, .userInitiated is not a serial queue
 		if waitingForExport == 0 {
 			let filePath = URL(fileURLWithPath: NSString(string: NSTemporaryDirectory()).appendingPathComponent("allWorkouts.csv"))
 			let displayError = {
@@ -258,7 +261,8 @@ class ListTableViewController: UITableViewController, GADBannerViewDelegate, Wor
 				}
 			}
 			
-			var data = "Start\(CSVSeparator)End\(CSVSeparator)Duration\(CSVSeparator)Distance\(CSVSeparator)\("Average Heart Rate".toCSV())\(CSVSeparator)\("Max Heart Rate".toCSV())\(CSVSeparator)\("Average Pace".toCSV())\n"
+			let sep = CSVSeparator
+			var data = "Type\(sep)Start\(sep)End\(sep)Duration\(sep)Distance\(sep)\("Average Heart Rate".toCSV())\(sep)\("Max Heart Rate".toCSV())\(sep)\("Average Pace".toCSV())\(sep)\("Average Speed".toCSV())\n"
 			for w in self.exportWorkouts {
 				if w.hasError {
 					displayError()

--- a/Workout/Main.swift
+++ b/Workout/Main.swift
@@ -50,10 +50,11 @@ var areAdsEnabled: Bool {
 let removeAdsId = "MarcoBoschi.ios.Workout.removeAds"
 let iapManager = InAppPurchaseManager(productIds: [removeAdsId], inUserDefaults: preferences)
 
-let distanceF = { Void -> LengthFormatter in
-	let formatter = LengthFormatter()
-	formatter.numberFormatter.usesSignificantDigits = false
-	formatter.numberFormatter.maximumFractionDigits = 3
+let distanceF = { Void -> NumberFormatter in
+	let formatter = NumberFormatter()
+	formatter.numberStyle = .decimal
+	formatter.usesSignificantDigits = false
+	formatter.maximumFractionDigits = 2
 	
 	return formatter
 }()
@@ -78,26 +79,36 @@ let integerF = { Void -> NumberFormatter in
 
 extension TimeInterval {
 	
-	func getFormattedPace() -> String {
-		return getDuration() + "/km"
+	///- parameter forLengthUnit: The unit to use to represent the distance component
+	///- returns: The formatted value, considered in time per `forLengthUnit`.
+	func getFormattedPace(forLengthUnit unit: HKUnit) -> String {
+		return getDuration() + "/\(unit.description)"
 	}
 	
 }
 
 extension Double {
 	
-	///- returns: The formatted value, considered in kilometers.
-	func getFormattedDistance() -> String {
-		return distanceF.string(fromValue: self, unit: .kilometer)
+	///- returns: The formatted value, considered in the passed unit.
+	func getFormattedDistance(withUnit unit: HKUnit) -> String {
+		return distanceF.string(from: NSNumber(value: self))! + " \(unit.description)"
 	}
 	
-	///- returns: The formatted value, considered in kilometers per hour.
-	func getFormattedSpeed() -> String {
-		return speedF.string(from: NSNumber(value: self))! + " km/h"
+	///- parameter forLengthUnit: The unit to use to represent the distance component
+	///- returns: The formatted value, considered in `forLengthUnit` per hour.
+	func getFormattedSpeed(forLengthUnit unit: HKUnit) -> String {
+		return speedF.string(from: NSNumber(value: self))! + " \(unit.description)/h"
 	}
 	
 	func getFormattedHeartRate() -> String {
 		return integerF.string(from: NSNumber(value: self))! + " bpm"
+	}
+	
+	func convertFrom(_ un1: HKUnit, to un2: HKUnit) -> Double {
+		let quant = HKQuantity(unit: un1, doubleValue: self)
+		precondition(quant.is(compatibleWith: un2), "Units are not compatible")
+		
+		return quant.doubleValue(for: un2)
 	}
 	
 }

--- a/Workout/Main.swift
+++ b/Workout/Main.swift
@@ -30,12 +30,6 @@ let healthReadData: Set<HKObjectType> = {
 	
 	return res
 }()
-///List of supported workouts.
-let workoutTypes = [
-	HKWorkoutActivityType.running,
-	.functionalStrengthTraining,
-	.swimming
-]
 ///Enable or disable ads override.
 let adsEnable = true
 ///Ads ID.

--- a/Workout/Main.swift
+++ b/Workout/Main.swift
@@ -10,9 +10,32 @@ import Foundation
 import HealthKit
 import MBLibrary
 
-let healthStore = HKHealthStore()
 ///Keep track of the version of health authorization required, increase this number to automatically display an authorization request.
-let authRequired = 1
+let authRequired = 2
+///List of health data to require access to.
+let healthReadData: Set<HKObjectType> = {
+	var res: Set<HKObjectType> = [
+		HKObjectType.workoutType(),
+		HKObjectType.quantityType(forIdentifier: .heartRate)!,
+		HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+		HKObjectType.quantityType(forIdentifier: .stepCount)!
+	]
+	
+	if #available(iOS 10, *) {
+		res.formUnion([
+			HKObjectType.quantityType(forIdentifier: .distanceSwimming)!,
+			HKObjectType.quantityType(forIdentifier: .swimmingStrokeCount)!
+		])
+	}
+	
+	return res
+}()
+///List of supported workouts.
+let workoutTypes = [
+	HKWorkoutActivityType.running,
+	.functionalStrengthTraining,
+	.swimming
+]
 ///Enable or disable ads override.
 let adsEnable = true
 ///Ads ID.
@@ -21,6 +44,8 @@ let adsEnable = true
 let adsID = "ca-app-pub-7085161342725707/5192351673"
 ///Filter for step count source name.
 let stepSourceFilter = "Watch"
+
+let healthStore = HKHealthStore()
 
 var areAdsEnabled: Bool {
 	return adsEnable && !iapManager.isProductPurchased(pId: removeAdsId)
@@ -67,18 +92,6 @@ extension Double {
 	
 	func getFormattedSteps() -> String {
 		return integerF.string(from: NSNumber(value: self))! + " steps"
-	}
-	
-}
-
-extension HKUnit {
-	
-	class func heartRate() -> HKUnit {
-		return HKUnit.count().unitDivided(by: HKUnit.minute())
-	}
-	
-	class func steps() -> HKUnit {
-		return HKUnit.count()
 	}
 	
 }

--- a/Workout/Main.swift
+++ b/Workout/Main.swift
@@ -62,6 +62,15 @@ let distanceF = { Void -> LengthFormatter in
 	return formatter
 }()
 
+let speedF = { Void -> NumberFormatter in
+	let formatter = NumberFormatter()
+	formatter.numberStyle = .decimal
+	formatter.usesSignificantDigits = false
+	formatter.maximumFractionDigits = 1
+	
+	return formatter
+}()
+
 let integerF = { Void -> NumberFormatter in
 	let formatter = NumberFormatter()
 	formatter.numberStyle = .decimal
@@ -81,17 +90,25 @@ extension TimeInterval {
 
 extension Double {
 	
-	///- returns: The formatted values, considered in kilometers.
+	///- returns: The formatted value, considered in kilometers.
 	func getFormattedDistance() -> String {
 		return distanceF.string(fromValue: self, unit: .kilometer)
+	}
+	
+	///- returns: The formatted value, considered in kilometers per hour.
+	func getFormattedSpeed() -> String {
+		return speedF.string(from: NSNumber(value: self))! + " km/h"
 	}
 	
 	func getFormattedHeartRate() -> String {
 		return integerF.string(from: NSNumber(value: self))! + " bpm"
 	}
 	
-	func getFormattedSteps() -> String {
-		return integerF.string(from: NSNumber(value: self))! + " steps"
-	}
+}
+
+extension DispatchQueue {
+	
+	///Serial queue to synchronize access to counters and data when loading and exporting workouts.
+	static let workout = DispatchQueue(label: "Marco-Boschi.ios.Workout.loadExport")
 	
 }

--- a/Workout/RunningWorkout.swift
+++ b/Workout/RunningWorkout.swift
@@ -16,7 +16,7 @@ class RunninWorkout: Workout {
 		super.init(raw, delegate: del)
 		
 		self.addDetails([.pace, .heart, .steps])
-		self.addRequest(for: .distanceWalkingRunning, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+		self.addRequest(for: .distanceWalkingRunning, withUnit: .meter(), andTimeType: .ranged, searchingBy: .workout)
 		self.addRequest(for: .stepCount, withUnit: .steps(), andTimeType: .ranged, searchingBy: .time)
 	}
 	

--- a/Workout/RunningWorkout.swift
+++ b/Workout/RunningWorkout.swift
@@ -1,0 +1,25 @@
+//
+//  RunningWorkout.swift
+//  Workout
+//
+//  Created by Marco Boschi on 04/03/2017.
+//  Copyright © 2017 Marco Boschi. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+import MBLibrary
+
+class RunninWorkout: Workout {
+	
+	override init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
+		super.init(raw, delegate: del)
+		
+		self.addDetails()
+		self.addRequest(for: HKQuantityTypeIdentifier.distanceWalkingRunning.getType()!, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+		self.addRequest(for: HKQuantityTypeIdentifier.stepCount.getType()!, withUnit: .steps(), andTimeType: .ranged, searchingBy: .time)
+	}
+	
+	// TODO: Define an array with the content of details, the order in which they should appear and if they're a cumulative or average data using `DataType`.
+	
+}

--- a/Workout/RunningWorkout.swift
+++ b/Workout/RunningWorkout.swift
@@ -12,7 +12,7 @@ import MBLibrary
 
 class RunninWorkout: Workout {
 	
-	override init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
+	required init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
 		super.init(raw, delegate: del)
 		
 		self.addDetails([.pace, .heart, .steps])

--- a/Workout/RunningWorkout.swift
+++ b/Workout/RunningWorkout.swift
@@ -15,11 +15,9 @@ class RunninWorkout: Workout {
 	override init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
 		super.init(raw, delegate: del)
 		
-		self.addDetails()
-		self.addRequest(for: HKQuantityTypeIdentifier.distanceWalkingRunning.getType()!, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
-		self.addRequest(for: HKQuantityTypeIdentifier.stepCount.getType()!, withUnit: .steps(), andTimeType: .ranged, searchingBy: .time)
+		self.addDetails([.pace, .heart, .steps])
+		self.addRequest(for: .distanceWalkingRunning, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+		self.addRequest(for: .stepCount, withUnit: .steps(), andTimeType: .ranged, searchingBy: .time)
 	}
-	
-	// TODO: Define an array with the content of details, the order in which they should appear and if they're a cumulative or average data using `DataType`.
 	
 }

--- a/Workout/SwimmingWorkout.swift
+++ b/Workout/SwimmingWorkout.swift
@@ -12,7 +12,7 @@ import MBLibrary
 
 class SwimmingWorkout: Workout {
 	
-	override init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
+	required init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
 		super.init(raw, delegate: del)
 		
 		if #available(iOS 10, *) {

--- a/Workout/SwimmingWorkout.swift
+++ b/Workout/SwimmingWorkout.swift
@@ -16,12 +16,10 @@ class SwimmingWorkout: Workout {
 		super.init(raw, delegate: del)
 		
 		if #available(iOS 10, *) {
-			self.addDetails()
-			self.addRequest(for: HKQuantityTypeIdentifier.distanceSwimming.getType()!, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
-			self.addRequest(for: HKQuantityTypeIdentifier.swimmingStrokeCount.getType()!, withUnit: .strokes(), andTimeType: .ranged, searchingBy: .time)
+			self.addDetails([.speed, .heart, .strokes])
+			self.addRequest(for: .distanceSwimming, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+			self.addRequest(for: .swimmingStrokeCount, withUnit: .strokes(), andTimeType: .ranged, searchingBy: .time)
 		}
 	}
-	
-	// TODO: Define an array with the content of details, the order in which they should appear and if they're a cumulative or average data using `DataType`.
 	
 }

--- a/Workout/SwimmingWorkout.swift
+++ b/Workout/SwimmingWorkout.swift
@@ -14,10 +14,11 @@ class SwimmingWorkout: Workout {
 	
 	required init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
 		super.init(raw, delegate: del)
+		self.setLengthPrefixFor(distance: .none, speed: .kilo, pace: .kilo)
 		
 		if #available(iOS 10, *) {
 			self.addDetails([.speed, .heart, .strokes])
-			self.addRequest(for: .distanceSwimming, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+			self.addRequest(for: .distanceSwimming, withUnit: .meter(), andTimeType: .ranged, searchingBy: .workout)
 			self.addRequest(for: .swimmingStrokeCount, withUnit: .strokes(), andTimeType: .ranged, searchingBy: .time)
 		}
 	}

--- a/Workout/SwimmingWorkout.swift
+++ b/Workout/SwimmingWorkout.swift
@@ -1,0 +1,27 @@
+//
+//  SwimmingWorkout.swift
+//  Workout
+//
+//  Created by Marco Boschi on 04/03/2017.
+//  Copyright © 2017 Marco Boschi. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+import MBLibrary
+
+class SwimmingWorkout: Workout {
+	
+	override init(_ raw: HKWorkout, delegate del: WorkoutDelegate?) {
+		super.init(raw, delegate: del)
+		
+		if #available(iOS 10, *) {
+			self.addDetails()
+			self.addRequest(for: HKQuantityTypeIdentifier.distanceSwimming.getType()!, withUnit: .kilometer(), andTimeType: .ranged, searchingBy: .workout)
+			self.addRequest(for: HKQuantityTypeIdentifier.swimmingStrokeCount.getType()!, withUnit: .strokes(), andTimeType: .ranged, searchingBy: .time)
+		}
+	}
+	
+	// TODO: Define an array with the content of details, the order in which they should appear and if they're a cumulative or average data using `DataType`.
+	
+}

--- a/Workout/SwimmingWorkout.swift
+++ b/Workout/SwimmingWorkout.swift
@@ -17,7 +17,7 @@ class SwimmingWorkout: Workout {
 		self.setLengthPrefixFor(distance: .none, speed: .kilo, pace: .kilo)
 		
 		if #available(iOS 10, *) {
-			self.addDetails([.speed, .heart, .strokes])
+			self.addDetails([.pace, .heart, .strokes])
 			self.addRequest(for: .distanceSwimming, withUnit: .meter(), andTimeType: .ranged, searchingBy: .workout)
 			self.addRequest(for: .swimmingStrokeCount, withUnit: .strokes(), andTimeType: .ranged, searchingBy: .time)
 		}

--- a/Workout/Workout.swift
+++ b/Workout/Workout.swift
@@ -183,7 +183,10 @@ class Workout {
 				}
 			}
 			
-			self.requestDone += 1
+			//Move to a serial queue to synchronize access to counter
+			DispatchQueue.userInitiated.async {
+				self.requestDone += 1
+			}
 		}
 		
 		requests.append(query)

--- a/Workout/Workout.swift
+++ b/Workout/Workout.swift
@@ -83,7 +83,7 @@ class Workout {
 	var avgHeart: Double? {
 		return heartData.count > 0 ? heartData.reduce(0) { $0 + $1 } / Double(heartData.count) : nil
 	}
-	///Avarage pace of the workout in seconds per `paceUnit`.
+	///Average pace of the workout in seconds per `paceUnit`.
 	var pace: TimeInterval? {
 		guard let dist = raw.totalDistance?.doubleValue(for: paceUnit) else {
 			return nil
@@ -91,7 +91,7 @@ class Workout {
 		
 		return duration / dist
 	}
-	///Avarage speed of the workout in `speedUnit` per hour.
+	///Average speed of the workout in `speedUnit` per hour.
 	var speed: Double? {
 		guard let dist = raw.totalDistance?.doubleValue(for: speedUnit) else {
 			return nil
@@ -180,7 +180,7 @@ class Workout {
 	}
 	
 	///Add a query to load data for passed type.
-	/// - important: Make sure that when loading distance data (`.distanceWalkingRunning` and `.distanceSwimming`) you specifies `.meter()` as unit, use `setLengthPrefixFor(distance: _, speed: _, pace: _)` to specify the desired prefixes.
+	/// - important: Make sure that when loading distance data (`.distanceWalkingRunning`, `.distanceSwimming` or others) you specifies `.meter()` as unit, use `setLengthPrefixFor(distance: _, speed: _, pace: _)` to specify the desired prefixes.
 	private func addRequest(for typeID: HKQuantityTypeIdentifier, withUnit unit: HKUnit, andTimeType tType: DataPointType, searchingBy pred: SearchType, isBase: Bool) {
 		guard !loading && !loaded else {
 			return
@@ -245,7 +245,7 @@ class Workout {
 	}
 	
 	///Add a query to load data for passed type.
-	/// - important: Make sure that when loading distance data (`.distanceWalkingRunning` and `.distanceSwimming`) you specifies `.meter()` as unit, use `setLengthPrefixFor(distance: _, speed: _, pace: _)` to specify the desired prefixes.
+	/// - important: Make sure that when loading distance data (`.distanceWalkingRunning`, `.distanceSwimming` or others) you specifies `.meter()` as unit, use `setLengthPrefixFor(distance: _, speed: _, pace: _)` to specify the desired prefixes.
 	func addRequest(for typeID: HKQuantityTypeIdentifier, withUnit unit: HKUnit, andTimeType tType: DataPointType, searchingBy pred: SearchType) {
 		self.addRequest(for: typeID, withUnit: unit, andTimeType: tType, searchingBy: pred, isBase: false)
 	}

--- a/Workout/Workout.swift
+++ b/Workout/Workout.swift
@@ -88,24 +88,28 @@ class Workout {
 	private let workoutPredicate: NSPredicate!
 	private let timePredicate: NSPredicate!
 	private let startDateSort: NSSortDescriptor!
-	private let queryNoLimit = Int(HKObjectQueryNoLimit)
+	private let queryNoLimit = HKObjectQueryNoLimit
 	
 	enum SearchType {
 		case time, workout
 	}
 	
 	class func workoutFor(raw: HKWorkout, delegate: WorkoutDelegate? = nil) -> Workout {
+		let wClass: Workout.Type
+		
 		switch raw.workoutActivityType {
 		case .running:
-			return RunninWorkout(raw, delegate: delegate)
+			wClass = RunninWorkout.self
 		case .swimming:
-			return SwimmingWorkout(raw, delegate: delegate)
+			wClass = SwimmingWorkout.self
 		default:
-			return Workout(raw, delegate: delegate)
+			wClass = Workout.self
 		}
+		
+		return wClass.init(raw, delegate: delegate)
 	}
 	
-	init(_ raw: HKWorkout, delegate del: WorkoutDelegate? = nil) {
+	required init(_ raw: HKWorkout, delegate del: WorkoutDelegate? = nil) {
 		self.raw = raw
 		self.delegate = del
 		

--- a/Workout/WorkoutDetail.swift
+++ b/Workout/WorkoutDetail.swift
@@ -1,0 +1,92 @@
+//
+//  WorkoutDetail.swift
+//  Workout
+//
+//  Created by Marco Boschi on 05/03/2017.
+//  Copyright © 2017 Marco Boschi. All rights reserved.
+//
+
+import UIKit
+import HealthKit
+
+class WorkoutDetail {
+	
+	static let noData = "–"
+	
+	let name: String
+	private let color: UIColor
+	private let displayer: (WorkoutMinute) -> String?
+	private let exporter: (WorkoutMinute) -> String?
+	
+	///Create a new workout detail.
+	///- parameter name: The name of the detail used as header when exporting.
+	///- parameter valueFormatter: A block called to format the value for display on screen, return `nil` if the value is not available.
+	///- parameter exportFormatter: A block called to format the value for exporting, return `nil` if the value is not available, remember to invoke `.toCSV()` inside the block.
+	private init(name: String, valueFormatter v: @escaping (WorkoutMinute) -> String?, exportFormatter e: @escaping (WorkoutMinute) -> String?, color c: UIColor = #colorLiteral(red: 0.5568627451, green: 0.5568627451, blue: 0.5764705882, alpha: 1)) {
+		self.name = name
+		self.color = c
+		self.displayer = v
+		self.exporter = e
+	}
+	
+	func newView() -> UILabel {
+		let res = UILabel()
+		res.textColor = color
+		
+		return res
+	}
+	
+	func update(view: UILabel, with val: WorkoutMinute) {
+		view.text = displayer(val) ?? WorkoutDetail.noData
+	}
+	
+	func export(val: WorkoutMinute) -> String {
+		return exporter(val) ?? ""
+	}
+	
+	static let time = WorkoutDetail(name: "Time", valueFormatter: { (m) in
+		return "\(m.minute)m"
+	}, exportFormatter: { (m) in
+		return m.startTime.getDuration().toCSV()
+	}, color: .black)
+	
+	static let pace = WorkoutDetail(name: "Pace", valueFormatter: { (m) in
+		return m.pace?.getFormattedPace()
+	}, exportFormatter: { (m) in
+		return m.pace?.getDuration().toCSV()
+	})
+	
+	static let speed = WorkoutDetail(name: "Speed", valueFormatter: { (m) in
+		return m.speed?.getFormattedSpeed()
+	}, exportFormatter: { (m) in
+		return m.speed?.toCSV()
+	})
+	
+	static let heart = WorkoutDetail(name: "Heart Rate", valueFormatter: { (m) in
+		return m.bpm?.getFormattedHeartRate()
+	}, exportFormatter: { (m) in
+		return m.bpm?.toCSV()
+	})
+	
+	static let steps = WorkoutDetail(name: "Steps", valueFormatter: { (m) in
+		guard let count = m.getTotal(for: .stepCount), let txt = integerF.string(from: NSNumber(value: count)) else {
+			return nil
+		}
+		
+		return txt + " " + NSLocalizedString("STEPS", comment: "steps")
+	}, exportFormatter: { (m) in
+		return m.getTotal(for: .stepCount)?.toCSV()
+	})
+	
+	@available(iOS 10, *)
+	static let strokes = WorkoutDetail(name: "Strokes", valueFormatter: { (m) in
+		guard let count = m.getTotal(for: .swimmingStrokeCount), let txt = integerF.string(from: NSNumber(value: count)) else {
+			return nil
+		}
+		
+		return txt + " " + NSLocalizedString("STROKES", comment: "strokes")
+	}, exportFormatter: { (m) in
+		return m.getTotal(for: .swimmingStrokeCount)?.toCSV()
+	})
+	
+}

--- a/Workout/WorkoutDetail.swift
+++ b/Workout/WorkoutDetail.swift
@@ -18,7 +18,7 @@ class WorkoutDetail {
 	private let displayer: (WorkoutMinute) -> String?
 	private let exporter: (WorkoutMinute) -> String?
 	
-	///Create a new workout detail.
+	///Create a new workout detail to present values stored inside a `WorkoutMinute`.
 	///- parameter name: The name of the detail used as header when exporting.
 	///- parameter valueFormatter: A block called to format the value for display on screen, return `nil` if the value is not available.
 	///- parameter exportFormatter: A block called to format the value for exporting, return `nil` if the value is not available, remember to invoke `.toCSV()` inside the block.
@@ -44,30 +44,35 @@ class WorkoutDetail {
 		return exporter(val) ?? ""
 	}
 	
+	///Provides information about the time.
 	static let time = WorkoutDetail(name: "Time", valueFormatter: { (m) in
 		return "\(m.minute)m"
 	}, exportFormatter: { (m) in
 		return m.startTime.getDuration().toCSV()
 	}, color: .black)
 	
+	///Provides the avarage pace in seconds per kilometer.
 	static let pace = WorkoutDetail(name: "Pace", valueFormatter: { (m) in
-		return m.pace?.getFormattedPace()
+		return m.pace?.getFormattedPace(forLengthUnit: m.owner.paceUnit)
 	}, exportFormatter: { (m) in
 		return m.pace?.getDuration().toCSV()
 	})
 	
+	///Provides the avarage speed in kilometer per hour.
 	static let speed = WorkoutDetail(name: "Speed", valueFormatter: { (m) in
-		return m.speed?.getFormattedSpeed()
+		return m.speed?.getFormattedSpeed(forLengthUnit: m.owner.speedUnit)
 	}, exportFormatter: { (m) in
 		return m.speed?.toCSV()
 	})
 	
+	///Provides the avarage heart rate.
 	static let heart = WorkoutDetail(name: "Heart Rate", valueFormatter: { (m) in
 		return m.bpm?.getFormattedHeartRate()
 	}, exportFormatter: { (m) in
 		return m.bpm?.toCSV()
 	})
 	
+	///Provides the number of steps.
 	static let steps = WorkoutDetail(name: "Steps", valueFormatter: { (m) in
 		guard let count = m.getTotal(for: .stepCount), let txt = integerF.string(from: NSNumber(value: count)) else {
 			return nil
@@ -78,6 +83,7 @@ class WorkoutDetail {
 		return m.getTotal(for: .stepCount)?.toCSV()
 	})
 	
+	///Provides the number of strokes.
 	@available(iOS 10, *)
 	static let strokes = WorkoutDetail(name: "Strokes", valueFormatter: { (m) in
 		guard let count = m.getTotal(for: .swimmingStrokeCount), let txt = integerF.string(from: NSNumber(value: count)) else {

--- a/Workout/WorkoutDetail.swift
+++ b/Workout/WorkoutDetail.swift
@@ -51,21 +51,21 @@ class WorkoutDetail {
 		return m.startTime.getDuration().toCSV()
 	}, color: .black)
 	
-	///Provides the avarage pace in seconds per kilometer.
+	///Provides the average pace in seconds per kilometer.
 	static let pace = WorkoutDetail(name: "Pace", valueFormatter: { (m) in
 		return m.pace?.getFormattedPace(forLengthUnit: m.owner.paceUnit)
 	}, exportFormatter: { (m) in
 		return m.pace?.getDuration().toCSV()
 	})
 	
-	///Provides the avarage speed in kilometer per hour.
+	///Provides the average speed in kilometer per hour.
 	static let speed = WorkoutDetail(name: "Speed", valueFormatter: { (m) in
 		return m.speed?.getFormattedSpeed(forLengthUnit: m.owner.speedUnit)
 	}, exportFormatter: { (m) in
 		return m.speed?.toCSV()
 	})
 	
-	///Provides the avarage heart rate.
+	///Provides the average heart rate.
 	static let heart = WorkoutDetail(name: "Heart Rate", valueFormatter: { (m) in
 		return m.bpm?.getFormattedHeartRate()
 	}, exportFormatter: { (m) in

--- a/Workout/WorkoutDetailTVCell.swift
+++ b/Workout/WorkoutDetailTVCell.swift
@@ -10,9 +10,19 @@ import UIKit
 
 class WorkoutDetailTableViewCell: UITableViewCell {
 
-	@IBOutlet weak var time: UILabel!
-	@IBOutlet weak var pace: UILabel!
-	@IBOutlet weak var bpm: UILabel!
-	@IBOutlet weak var steps: UILabel!
+	@IBOutlet weak var stack: UIStackView!
+	
+	func update(for details: [WorkoutDetail], withData data: WorkoutMinute) {
+		for v in stack.arrangedSubviews {
+			v.removeFromSuperview()
+		}
+		
+		for d in [.time] + details {
+			let view = d.newView()
+			d.update(view: view, with: data)
+			
+			stack.addArrangedSubview(view)
+		}
+	}
 
 }

--- a/Workout/WorkoutMinute.swift
+++ b/Workout/WorkoutMinute.swift
@@ -48,7 +48,7 @@ class WorkoutMinute: CustomStringConvertible {
 	var distance: Double? {
 		return rawDistance?.convertFrom(.meter(), to: owner.distanceUnit)
 	}
-	///Avarage pace of the minute in seconds per `paceUnit` specified by `owner`.
+	///Average pace of the minute in seconds per `paceUnit` specified by `owner`.
 	var pace: TimeInterval? {
 		if let d = rawDistance?.convertFrom(.meter(), to: owner.paceUnit) {
 			return duration / d
@@ -56,7 +56,7 @@ class WorkoutMinute: CustomStringConvertible {
 			return nil
 		}
 	}
-	///Avarage speed of the minute in `speedUnit`, specified by `owner`, per hour.
+	///Average speed of the minute in `speedUnit`, specified by `owner`, per hour.
 	var speed: Double? {
 		guard let dist = rawDistance?.convertFrom(.meter(), to: owner.speedUnit) else {
 			return nil

--- a/Workout/WorkoutMinute.swift
+++ b/Workout/WorkoutMinute.swift
@@ -91,6 +91,12 @@ class WorkoutMinute: CustomStringConvertible {
 	///- returns: `true` if some of the data belongs to following minutes, `false` otherwise.
 	@discardableResult func add(_ data: RangedDataPoint, ofType type: HKQuantityTypeIdentifier) -> Bool {
 		let val: Double?
+		guard data.start != data.end else {
+			let instant = InstantDataPoint(time: data.start, value: data.value)
+			
+			return self.add(instant, ofType: type)
+		}
+		
 		if data.start >= startTime && data.start < endTime {
 			// Start time is in range
 			let frac = (min(endTime, data.end) - data.start) / data.duration

--- a/Workout/WorkoutTVC.swift
+++ b/Workout/WorkoutTVC.swift
@@ -47,7 +47,7 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
     // MARK: - Table view data source
 
 	override func numberOfSections(in tableView: UITableView) -> Int {
-		return error ? 1 : 2
+		return error ? 1 : (workout.details != nil ? 2 : 1)
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -55,7 +55,7 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
 			return 1
 		}
 		
-		return section == 0 ? 7 : workout.details.count
+		return section == 0 ? 9 : workout.details?.count ?? 0
     }
 
 
@@ -75,12 +75,9 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
 		
 		if indexPath.section == 1 {
 			let cell = tableView.dequeueReusableCell(withIdentifier: "detail", for: indexPath) as! WorkoutDetailTableViewCell
-			let d = workout.details[indexPath.row]
+			let d = workout.details![indexPath.row]
 			
-			cell.time.text = "\(d.minute)m"
-			cell.pace.text = d.pace?.getFormattedPace() ?? "-"
-			cell.bpm.text = d.bpm?.getFormattedHeartRate() ?? "-"
-			cell.steps.text = d.steps?.getFormattedSteps() ?? "-"
+			cell.update(for: workout.displayDetail!, withData: d)
 			
 			return cell
 		} else {
@@ -89,26 +86,32 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
 			let title: String
 			switch indexPath.row {
 			case 0:
+				title = "TYPE"
+				cell.detailTextLabel?.text = workout.type.name
+			case 1:
 				title = "START"
 				cell.detailTextLabel?.text = workout.startDate.getFormattedDateTime()
-			case 1:
+			case 2:
 				title = "END"
 				cell.detailTextLabel?.text = workout.endDate.getFormattedDateTime()
-			case 2:
+			case 3:
 				title = "DURATION"
 				cell.detailTextLabel?.text = workout.duration.getDuration()
-			case 3:
-				title = "DISTANCE"
-				cell.detailTextLabel?.text = workout.totalDistance.getFormattedDistance()
 			case 4:
-				title = "AVG_HEART"
-				cell.detailTextLabel?.text = workout.avgHeart?.getFormattedHeartRate() ?? "-"
+				title = "DISTANCE"
+				cell.detailTextLabel?.text = workout.totalDistance?.getFormattedDistance() ?? WorkoutDetail.noData
 			case 5:
-				title = "MAX_HEART"
-				cell.detailTextLabel?.text = workout.maxHeart?.getFormattedHeartRate() ?? "-"
+				title = "AVG_HEART"
+				cell.detailTextLabel?.text = workout.avgHeart?.getFormattedHeartRate() ?? WorkoutDetail.noData
 			case 6:
+				title = "MAX_HEART"
+				cell.detailTextLabel?.text = workout.maxHeart?.getFormattedHeartRate() ?? WorkoutDetail.noData
+			case 7:
 				title = "AVG_PACE";
-				cell.detailTextLabel?.text = workout.pace.getFormattedPace()
+				cell.detailTextLabel?.text = workout.pace?.getFormattedPace() ?? WorkoutDetail.noData
+			case 8:
+				title = "AVG_SPEED";
+				cell.detailTextLabel?.text = workout.speed?.getFormattedSpeed() ?? WorkoutDetail.noData
 			default:
 				return cell
 			}

--- a/Workout/WorkoutTVC.swift
+++ b/Workout/WorkoutTVC.swift
@@ -99,7 +99,7 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
 				cell.detailTextLabel?.text = workout.duration.getDuration()
 			case 4:
 				title = "DISTANCE"
-				cell.detailTextLabel?.text = workout.totalDistance?.getFormattedDistance() ?? WorkoutDetail.noData
+				cell.detailTextLabel?.text = workout.totalDistance?.getFormattedDistance(withUnit: workout.distanceUnit) ?? WorkoutDetail.noData
 			case 5:
 				title = "AVG_HEART"
 				cell.detailTextLabel?.text = workout.avgHeart?.getFormattedHeartRate() ?? WorkoutDetail.noData
@@ -108,10 +108,11 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
 				cell.detailTextLabel?.text = workout.maxHeart?.getFormattedHeartRate() ?? WorkoutDetail.noData
 			case 7:
 				title = "AVG_PACE";
-				cell.detailTextLabel?.text = workout.pace?.getFormattedPace() ?? WorkoutDetail.noData
+				cell.detailTextLabel?.text = workout.pace?.getFormattedPace(forLengthUnit: workout.paceUnit) ?? WorkoutDetail.noData
 			case 8:
 				title = "AVG_SPEED";
-				cell.detailTextLabel?.text = workout.speed?.getFormattedSpeed() ?? WorkoutDetail.noData
+				cell.detailTextLabel?.text = workout.speed?.getFormattedSpeed(forLengthUnit: workout.speedUnit
+					) ?? WorkoutDetail.noData
 			default:
 				return cell
 			}

--- a/Workout/WorkoutTVC.swift
+++ b/Workout/WorkoutTVC.swift
@@ -27,7 +27,8 @@ class WorkoutTableViewController: UITableViewController, WorkoutDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        workout = Workout(rawWorkout, delegate: self)
+        workout = Workout.workoutFor(raw: rawWorkout, delegate: self)
+		workout.load()
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Refactor workout classes to allow loading of arbitrary workout types and easy extendibility based on what proposed in #1.

This include support for swimming workout (`HKWorkoutActivityType.swimming`) and lifting (`HKWorkoutActivityType.functionalStrengthTraining`). As additional details for swimming workouts are available only on iOS 10 and later on older versions a swimming workout will behave like a simple one without any detail.

To do list:
- [x] Refactor model classes
- Update UI to load new workouts
  - [x] Workout list
  - [x] Workout detail
- [x] Test new data loading system for new workout types
- [x] Upgrade exporting capabilities to support multiple workout types