### PR TITLE
UPD - String too long in french translation

### DIFF
--- a/Workout/fr.lproj/Localizable.strings
+++ b/Workout/fr.lproj/Localizable.strings
@@ -19,7 +19,7 @@
 
 // MARK: - Errors
 
-"WRKT_ERR_LOADING" = "Impossible de charger les données d’entraînement";
+"WRKT_ERR_LOADING" = "Impossible de charger les données de Santé";
 "WRKT_ERR_NO_HEALTH" = "Les données de Santé ne sont pas disponibles";
 
 // MARK: - Workout List View


### PR DESCRIPTION
Replacing "Workout" (entraînements) with "Health" (santé)

Like said in https://github.com/piscoTech/Workout/issues/16